### PR TITLE
create team member route

### DIFF
--- a/src/app/api/team-members/route.ts
+++ b/src/app/api/team-members/route.ts
@@ -1,0 +1,53 @@
+import { prisma } from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+import { TeamRole } from '@prisma/client';
+
+/**
+ * Creates a new team member
+ * @param request - The request object
+ * @returns The response object
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+
+  try {
+
+    // Validate the request body
+    const { userId, teamId, role } = await request.json();
+
+    // Check if the userId and teamId are provided
+    if (!userId || !teamId || !role ) {
+      return NextResponse.json({ error: 'userId, teamId, and role are required' }, { status: 400 });
+    }
+
+    // Validate and parse userId and teamId as integers
+    const parsedUserId: number = parseInt(userId);
+    const parsedTeamId: number = parseInt(teamId);
+    
+    if (isNaN(parsedUserId) || isNaN(parsedTeamId)) {
+      return NextResponse.json({ error: 'userId and teamId must be valid integers' }, { status: 400 });
+    }
+
+    // Validate role using Prisma enum
+    const validRoles = Object.values(TeamRole);
+    if (role && !validRoles.includes(role as TeamRole)) {
+      return NextResponse.json({ 
+        error: `Invalid role. Must be one of: ${validRoles.join(', ')}` 
+      }, { status: 400 });
+    }
+
+    // Create the team member
+    const teamMember = await prisma.teamMember.create({
+      data: { 
+        userId: parsedUserId, 
+        teamId: parsedTeamId,
+        role: role as TeamRole
+      },
+    });
+
+    // Return the team member if successful!
+    return NextResponse.json(teamMember, { status: 201 });
+  } catch (error) {
+    // Return an error response if failed to create team member!
+    return NextResponse.json({ error: 'Failed to create team member' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Created the team member post route. 

!!IMPORTANT!!! 

This was created assuming that the enum changes to the prisma schema were approved.

Requires the use of the role field, which is team_role in supabase, and TeamRole in the schema.

Successfully tested via Postman!
<img width="1091" height="603" alt="Screenshot 2025-11-13 at 9 19 14 PM" src="https://github.com/user-attachments/assets/19fa6fcb-f618-4d76-8638-78243cfcd735" />
