### PR TITLE
shared interfaces for db schema in frontend dashboard

### DIFF
--- a/src/components/AttendanceTable.tsx
+++ b/src/components/AttendanceTable.tsx
@@ -10,25 +10,7 @@ import {
 } from "@/components/ui/table"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-
-interface Attendance {
-  id: number
-  userId: number
-  meetingId: number
-  status: string
-  checkedInAt: Date | null
-  checkedOutAt: Date | null
-  notes: string | null
-  createdAt: Date
-  user: {
-    name: string | null
-    email: string
-  }
-  meeting: {
-    title: string
-    scheduledAt: Date
-  }
-}
+import { Attendance } from "@/types/dashboard";
 
 interface AttendanceTableProps {
   attendance: Attendance[]

--- a/src/components/FeedbackTable.tsx
+++ b/src/components/FeedbackTable.tsx
@@ -10,25 +10,7 @@ import {
 } from "@/components/ui/table"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-
-interface Feedback {
-  id: number
-  meetingId: number
-  authorId: number
-  rating: number | null
-  comment: string | null
-  category: string | null
-  isAnonymous: boolean
-  createdAt: Date
-  meeting: {
-    title: string
-    scheduledAt: Date
-  }
-  author: {
-    name: string | null
-    email: string
-  }
-}
+import { Feedback } from "@/types/dashboard";
 
 interface FeedbackTableProps {
   feedback: Feedback[]

--- a/src/components/MeetingsTable.tsx
+++ b/src/components/MeetingsTable.tsx
@@ -10,31 +10,7 @@ import {
 } from "@/components/ui/table"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-
-interface Meeting {
-  id: number
-  title: string
-  description: string | null
-  type: string
-  teamId: number | null
-  scheduledAt: Date
-  startedAt: Date | null
-  endedAt: Date | null
-  location: string | null
-  isRequired: boolean
-  maxCapacity: number | null
-  createdAt: Date
-  team?: {
-    name: string
-  }
-  attendance: Array<{
-    user: {
-      name: string | null
-      email: string
-    }
-    status: string
-  }>
-}
+import { Meeting } from "@/types/dashboard";
 
 interface MeetingsTableProps {
   meetings: Meeting[]

--- a/src/components/TeamsTable.tsx
+++ b/src/components/TeamsTable.tsx
@@ -10,22 +10,7 @@ import {
 } from "@/components/ui/table"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-
-interface Team {
-  id: number
-  name: string
-  description: string | null
-  isActive: boolean
-  createdAt: Date
-  updatedAt: Date
-  members: Array<{
-    user: {
-      name: string | null
-      email: string
-    }
-    role: string
-  }>
-}
+import { Team } from "@/types/dashboard";
 
 interface TeamsTableProps {
   teams: Team[]

--- a/src/components/UsersTable.tsx
+++ b/src/components/UsersTable.tsx
@@ -24,20 +24,7 @@ import {
   ModalForm,
   ModalButton,
 } from "@/components/ui/modal"
-
-interface User {
-  id: number
-  email: string
-  name: string | null
-  createdAt: Date
-  updatedAt: Date
-  teamMemberships: Array<{
-    team: {
-      name: string
-    }
-    role: string
-  }>
-}
+import { User } from "@/types/dashboard";
 
 interface UsersTableProps {
   users: User[]

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,92 @@
+export interface User {
+  id: number;
+  email: string;
+  name: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  teamMemberships: Array<{
+    team: {
+      name: string;
+    };
+    role: string;
+  }>;
+}
+
+export interface Team {
+  id: number;
+  name: string;
+  description: string | null;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  members: Array<{
+    user: {
+      name: string | null;
+      email: string;
+    };
+    role: string;
+  }>;
+}
+
+export interface Meeting {
+  id: number;
+  title: string;
+  description: string | null;
+  type: string;
+  teamId: number | null;
+  scheduledAt: Date;
+  startedAt: Date | null;
+  endedAt: Date | null;
+  location: string | null;
+  isRequired: boolean;
+  maxCapacity: number | null;
+  createdAt: Date;
+  team?: {
+    name: string;
+  };
+  attendance: Array<{
+    user: {
+      name: string | null;
+      email: string;
+    };
+    status: string;
+  }>;
+}
+
+export interface Attendance {
+  id: number;
+  userId: number;
+  meetingId: number;
+  status: string;
+  checkedInAt: Date | null;
+  checkedOutAt: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  user: {
+    name: string | null;
+    email: string;
+  };
+  meeting: {
+    title: string;
+    scheduledAt: Date;
+  };
+}
+
+export interface Feedback {
+  id: number;
+  meetingId: number;
+  authorId: number;
+  rating: number | null;
+  comment: string | null;
+  category: string | null;
+  isAnonymous: boolean;
+  createdAt: Date;
+  meeting: {
+    title: string;
+    scheduledAt: Date;
+  };
+  author: {
+    name: string | null;
+    email: string;
+  };
+}


### PR DESCRIPTION
Instead of hardcoding in the interfaces used for displaying db information into each table's component, moved those interfaces to a types folder that will be pulled in by each component.

For the future:
- Probably can abstract the table components into one shared component