### PR TITLE
Error message on screen instead of full pause on rendering frontend

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,49 +6,88 @@ import { AttendanceTable } from "@/components/AttendanceTable";
 import { FeedbackTable } from "@/components/FeedbackTable";
 import { prisma } from "@/lib/prisma";
 
-export default async function Home() {
-  
-  // Fetch all data from Prisma
-  const users = await prisma.user.findMany({
+async function getUsers() {
+  return prisma.user.findMany({
     include: {
       teamMemberships: {
         include: {
-          team: true
-        }
-      }
-    }
-  })
-  const teams = await prisma.team.findMany({
+          team: true,
+        },
+      },
+    },
+  });
+}
+
+async function getTeams() {
+  return prisma.team.findMany({
     include: {
       members: {
         include: {
-          user: true
-        }
-      }
-    }
-  })
-  const meetings = await prisma.meeting.findMany({
+          user: true,
+        },
+      },
+    },
+  });
+}
+
+async function getMeetings() {
+  return prisma.meeting.findMany({
     include: {
       attendance: {
         include: {
-          user: true
-        }
+          user: true,
+        },
       },
-      feedback: true
-    }
-  })
-  const attendance = await prisma.attendance.findMany({
+      feedback: true,
+    },
+  });
+}
+
+async function getAttendance() {
+  return prisma.attendance.findMany({
     include: {
       user: true,
-      meeting: true
-    }
-  })
-  const feedback = await prisma.feedback.findMany({
+      meeting: true,
+    },
+  });
+}
+
+async function getFeedback() {
+  return prisma.feedback.findMany({
     include: {
       meeting: true,
-      author: true
-    }
-  })
+      author: true,
+    },
+  });
+}
+
+export default async function Home() {
+  const emptyData = {
+    users: [] as Awaited<ReturnType<typeof getUsers>>,
+    teams: [] as Awaited<ReturnType<typeof getTeams>>,
+    meetings: [] as Awaited<ReturnType<typeof getMeetings>>,
+    attendance: [] as Awaited<ReturnType<typeof getAttendance>>,
+    feedback: [] as Awaited<ReturnType<typeof getFeedback>>,
+  };
+
+  let data = emptyData;
+  let dbUnavailable = false;
+
+  try {
+    // Fetch all data from Prisma. If this fails, render the dashboard with empty state data.
+    const [users, teams, meetings, attendance, feedback] = await Promise.all([
+      getUsers(),
+      getTeams(),
+      getMeetings(),
+      getAttendance(),
+      getFeedback(),
+    ]);
+
+    data = { users, teams, meetings, attendance, feedback };
+  } catch (error) {
+    dbUnavailable = true;
+    console.error("Database unavailable, rendering empty dashboard state:", error);
+  }
 
   return (
     <div className="container mx-auto p-6 space-y-8">
@@ -57,13 +96,18 @@ export default async function Home() {
         <h1 className="text-3xl font-bold">FirstByte Dashboard</h1>
         <p className="text-muted-foreground">Participation and engagement tracking</p>
       </div>
+      {dbUnavailable && (
+        <div className="rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-900">
+          Could not load database data right now. Showing an empty dashboard until the connection is restored.
+        </div>
+      )}
 
       <div className="grid gap-6">
-        <UsersTable users={users} />
-        <TeamsTable teams={teams} />
-        <MeetingsTable meetings={meetings} />
-        <AttendanceTable attendance={attendance} />
-        <FeedbackTable feedback={feedback} />
+        <UsersTable users={data.users} />
+        <TeamsTable teams={data.teams} />
+        <MeetingsTable meetings={data.meetings} />
+        <AttendanceTable attendance={data.attendance} />
+        <FeedbackTable feedback={data.feedback} />
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,91 +5,15 @@ import { MeetingsTable } from "@/components/MeetingsTable";
 import { AttendanceTable } from "@/components/AttendanceTable";
 import { FeedbackTable } from "@/components/FeedbackTable";
 import { prisma } from "@/lib/prisma";
-import { User } from "@/components/UsersTable";
-import { Team } from "@/components/TeamsTable";
-import { Meeting } from "@/components/MeetingsTable";
-import { Attendance } from "@/components/AttendanceTable";
-import { Feedback } from "@/components/FeedbackTable";
-
-/**
- * Fetches data from the API
- * @param endpoint - The endpoint to fetch data from
- * @returns the data requested from the API
- */
-async function fetchData<T>(endpoint: string): Promise<T> {
-  const response = await fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/${endpoint}`, {
-    cache: 'no-store',
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch data');
-  }
-
-  return response.json();
-}
-
-async function getUsers() {
-  return prisma.user.findMany({
-    include: {
-      teamMemberships: {
-        include: {
-          team: true,
-        },
-      },
-    },
-  });
-}
-
-async function getTeams() {
-  return prisma.team.findMany({
-    include: {
-      members: {
-        include: {
-          user: true,
-        },
-      },
-    },
-  });
-}
-
-async function getMeetings() {
-  return prisma.meeting.findMany({
-    include: {
-      attendance: {
-        include: {
-          user: true,
-        },
-      },
-      feedback: true,
-    },
-  });
-}
-
-async function getAttendance() {
-  return prisma.attendance.findMany({
-    include: {
-      user: true,
-      meeting: true,
-    },
-  });
-}
-
-async function getFeedback() {
-  return prisma.feedback.findMany({
-    include: {
-      meeting: true,
-      author: true,
-    },
-  });
-}
+import type { Attendance, Feedback, Meeting, Team, User } from "@/types/dashboard";
 
 export default async function Home() {
   const emptyData = {
-    users: [] as Awaited<ReturnType<typeof getUsers>>,
-    teams: [] as Awaited<ReturnType<typeof getTeams>>,
-    meetings: [] as Awaited<ReturnType<typeof getMeetings>>,
-    attendance: [] as Awaited<ReturnType<typeof getAttendance>>,
-    feedback: [] as Awaited<ReturnType<typeof getFeedback>>,
+    users: [] as User[],
+    teams: [] as Team[],
+    meetings: [] as Meeting[],
+    attendance: [] as Attendance[],
+    feedback: [] as Feedback[],
   };
 
   let data = emptyData;
@@ -98,11 +22,46 @@ export default async function Home() {
   try {
     // Fetch all data from Prisma. If this fails, render the dashboard with empty state data.
     const [users, teams, meetings, attendance, feedback] = await Promise.all([
-      getUsers(),
-      getTeams(),
-      getMeetings(),
-      getAttendance(),
-      getFeedback(),
+      prisma.user.findMany({
+        include: {
+          teamMemberships: {
+            include: {
+              team: true,
+            },
+          },
+        },
+      }),
+      prisma.team.findMany({
+        include: {
+          members: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      }),
+      prisma.meeting.findMany({
+        include: {
+          attendance: {
+            include: {
+              user: true,
+            },
+          },
+          feedback: true,
+        },
+      }),
+      prisma.attendance.findMany({
+        include: {
+          user: true,
+          meeting: true,
+        },
+      }),
+      prisma.feedback.findMany({
+        include: {
+          meeting: true,
+          author: true,
+        },
+      }),
     ]);
 
     data = { users, teams, meetings, attendance, feedback };


### PR DESCRIPTION
closed #36 

Now have empty arrays as a fallback to use to render dashboard data when there is a fetching error. Still shows errors in the console, but now renders the frontend as well!

<img width="1248" height="563" alt="Screenshot 2026-03-24 at 12 21 32 AM" src="https://github.com/user-attachments/assets/735f288e-ce1b-4acf-aa33-d26a10336ec1" />
