### PR TITLE
Attendance routes already mostly finished. Fixed some things

### DIFF
--- a/src/app/api/attendance/[id]/route.ts
+++ b/src/app/api/attendance/[id]/route.ts
@@ -7,10 +7,11 @@ import { AttendanceStatus } from "@prisma/client";
  */
 export async function GET(
     request: Request,
-    { params }: { params: { id: string } }
+    { params }: { params: Promise<{ id: string }> }
 ) {
     try {
-        const attendanceId = parseInt(params.id);
+        const { id } = await params;
+        const attendanceId = parseInt(id);
 
         if (isNaN(attendanceId)) {
             return NextResponse.json({ error: "Invalid attendance ID" }, { status: 400 });
@@ -36,10 +37,11 @@ export async function GET(
  */
 export async function PUT(
     request: Request,
-    { params }: { params: { id: string } }
+    { params }: { params: Promise<{ id: string }> }
 ) {
     try {
-        const attendanceId = parseInt(params.id);
+        const { id } = await params;
+        const attendanceId = parseInt(id);
 
         if (isNaN(attendanceId)) {
             return NextResponse.json({ error: "Invalid attendance ID" }, { status: 400 });
@@ -100,10 +102,11 @@ export async function PUT(
  */
 export async function DELETE(
     request: Request,
-    { params }: { params: { id: string } }
+    { params }: { params: Promise< { id: string } >}
 ) {
     try {
-        const attendanceId = parseInt(params.id);
+        const { id } = await params;
+        const attendanceId = parseInt(id);
 
         if (isNaN(attendanceId)) {
             return NextResponse.json({ error: "Invalid attendance ID" }, { status: 400 });

--- a/src/app/api/attendance/route.ts
+++ b/src/app/api/attendance/route.ts
@@ -6,9 +6,32 @@ import { AttendanceStatus } from "@prisma/client";
  * Gets all attendance records
  * @returns the attendance records
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
   try {
+    const { searchParams } = new URL(request.url);
+    const meetingIdParam = searchParams.get("meetingId");
+    const userIdParam = searchParams.get("userId");
+    
+    const where: { meetingId?: number; userId?: number } = {};
+
+    if (meetingIdParam != null) {
+      const meetingId = parseInt(meetingIdParam);
+      if (isNaN(meetingId)) {
+        return NextResponse.json({ error: "meetingId must be a valid integer" }, { status: 400 });
+      }
+      where.meetingId = meetingId;
+    }
+
+    if (userIdParam !== null) {
+      const userId = parseInt(userIdParam);
+      if (isNaN(userId)) {
+        return NextResponse.json({ error: "userId must be a valid integer"}, { status: 400 });
+      }
+      where.userId = userId;
+    }
+    
     const attendance = await prisma.attendance.findMany({
+      where,
       include: {
         user: true,
         meeting: true

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,7 +87,7 @@ export default async function Home() {
         <p className="text-muted-foreground">Participation and engagement tracking</p>
       </div>
       <form>
-        <button formAction={logOut} className="text-sm text-muted-foreground underline">
+        <button formAction={logOut} className="text-sm px-3 py-1.5 rounded-md bg-[rgb(76,111,78)] text-white hover:opacity-90 transition">
           Log out
         </button>
       </form>


### PR DESCRIPTION
Closing #51 — implemented as the PUT handler in app/api/attendance/[id]/route.ts (following our meeting PATCH→PUT convention). Updates status, checkedInAt, checkedOutAt, and notes independently or together via conditional spread, validates status against the AttendanceStatus enum (400 on invalid), returns 404 for a missing record, and 400 if no updatable field is supplied. Note for testers: the verb is PUT, not PATCH. Verified against single-field, multi-field, and invalid-enum cases. Closing #52  — implemented across app/api/attendance/route.ts (collection) and [id]/route.ts (single). The collection GET accepts ?meetingId= and ?userId= query params to fetch all records for a meeting or a user's full history; no params returns all records. Empty results return [] (not an error), and non-integer ids return 400. Covers both ACs plus the empty/multiple/invalid-id test cases. Closing #53 — implemented as the DELETE handler in app/api/attendance/[id]/route.ts. Deletes by id, returns a clean 404 for a non-existent/already-deleted record (findUnique pre-check, no crash), and 400 for an invalid id. Returns the deleted record in the response body. Verified against existing / already-deleted / invalid-id cases. Closing #50 — already implemented in app/api/attendance/route.ts. The POST handler satisfies all acceptance criteria: creates a record from userId + meetingId (with integer coercion + NaN guard), rejects duplicates via a userId_meetingId compound-key pre-check returning 409 (respecting @@unique([userId, meetingId])), and validates required fields + the status enum with 400s. Verified against valid / duplicate / missing-field cases. No new work needed.