### PR TITLE
Finished attendance check-in process/workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.544.0",
         "next": "15.4.5",
+        "qrcode.react": "^4.2.0",
         "radix-ui": "^1.6.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -3625,6 +3626,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/radix-ui": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",
     "next": "15.4.5",
+    "qrcode.react": "^4.2.0",
     "radix-ui": "^1.6.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/src/app/api/attendance/check-in/route.ts
+++ b/src/app/api/attendance/check-in/route.ts
@@ -1,0 +1,75 @@
+import { verifyCheckInCode } from "@/lib/attendance/check-in-code";
+import { syncUserToDb } from "@/lib/auth/sync-user";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+import { AttendanceStatus } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request): Promise<NextResponse> {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+        return NextResponse.json({ error: "Not autheticated" }, { status: 401 });
+    }
+
+    const { meetingId, code } = await request.json();
+
+    if (!meetingId || !code) {
+        return NextResponse.json(
+            { error: "meetingId and code are required" },
+            { status: 400 }
+        );
+    }
+
+    const parsedMeetingId = parseInt(meetingId);
+    if(isNaN(parsedMeetingId)) {
+        return NextResponse.json(
+            { error: "meetingId must be a valid integer" },
+            { status: 400 }
+        );
+    }
+
+    if(!verifyCheckInCode(parsedMeetingId, code)) {
+        return NextResponse.json(
+            { error: "Invlaid check-in code" },
+            { status: 403 }
+        );
+    }
+
+    await syncUserToDb(user);
+    const dbUser = await prisma.user.findUnique({ where: { email: user.email! } });
+    if(!dbUser) {
+        return NextResponse.json(
+            { error: "User record not found" },
+            { status: 404 }
+        );
+    }
+
+    try {
+        const attendance = await prisma.attendance.upsert({
+            where: {
+                userId_meetingId: {
+                    userId: dbUser.id,
+                    meetingId: parsedMeetingId,
+                },
+            },
+            update: {
+                status: AttendanceStatus.PRESENT,
+                checkedInAt: new Date(),
+            },
+            create: {
+                userId: dbUser.id,
+                meetingId: parsedMeetingId,
+                status: AttendanceStatus.PRESENT,
+                checkedInAt: new Date(),
+            },
+        });
+
+        return NextResponse.json(attendance, { status: 200 });
+    } catch (error) {
+        return NextResponse.json(
+            { error: "Failed to check in" },
+            { status: 500}
+        );
+    }
+}

--- a/src/app/api/meetings/route.ts
+++ b/src/app/api/meetings/route.ts
@@ -106,6 +106,35 @@ export async function POST(request: Request): Promise<NextResponse> {
       },
     });
 
+    // Determine the expected roster for this meeting.
+    // Team meeting (teamId set) -> that team's members.
+    // General meeting (teamId null) -> all club members.
+    let expectedUserIds: number[];
+
+    if (meeting.teamId != null) {
+      const teamMembers = await prisma.teamMember.findMany({
+        where: { teamId: meeting.teamId },
+        select: { userId: true },
+      });
+      expectedUserIds = teamMembers.map((m) => m.userId);
+    } else {
+      const allUsers = await prisma.user.findMany({
+        select: { id: true },
+      });
+      expectedUserIds = allUsers.map((u) => u.id)
+    }
+
+    if (expectedUserIds.length > 0) {
+      await prisma.attendance.createMany({
+        data: expectedUserIds.map((userId) => ({
+          userId,
+          meetingId: meeting.id,
+          status: "REGISTERED" as const
+        })),
+        skipDuplicates: true,
+      })
+    }
+
     return NextResponse.json(meeting, { status: 201 });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to create meeting' }, { status: 500 });

--- a/src/app/check-in/[meetingId]/CheckInForm.tsx
+++ b/src/app/check-in/[meetingId]/CheckInForm.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+interface CheckInFormProps {
+  meetingId: number;
+  meetingTitle: string;
+  initialCode: string;
+}
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+export function CheckInForm({ meetingId, meetingTitle, initialCode }: CheckInFormProps) {
+  const [code, setCode] = useState(initialCode);
+  const [status, setStatus] = useState<Status>("idle");
+  const [message, setMessage] = useState("");
+
+  async function handleCheckIn() {
+    setStatus("submitting");
+    setMessage("");
+    try {
+      const res = await fetch("/api/attendance/check-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ meetingId, code }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Check-in failed");
+      }
+      setStatus("success");
+      setMessage("You're checked in!");
+    } catch (err) {
+      setStatus("error");
+      setMessage(err instanceof Error ? err.message : "Something went wrong");
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Check in</CardTitle>
+        <CardDescription>{meetingTitle}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {status === "success" ? (
+          <p className="text-center font-medium text-green-700">{message}</p>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <label htmlFor="code" className="text-sm font-medium">Check-in code</label>
+              <Input
+                id="code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="Enter code"
+              />
+            </div>
+            <Button
+              onClick={handleCheckIn}
+              disabled={status === "submitting" || code.trim() === ""}
+              className="w-full"
+            >
+              {status === "submitting" ? "Checking in…" : "Confirm check-in"}
+            </Button>
+            {status === "error" && (
+              <p className="text-center text-sm text-destructive">{message}</p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/check-in/[meetingId]/page.tsx
+++ b/src/app/check-in/[meetingId]/page.tsx
@@ -1,0 +1,45 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
+import { CheckInForm } from "./CheckInForm";
+
+export default async function CheckInPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ meetingId: string }>;
+  searchParams: Promise<{ code?: string }>;
+}) {
+  const { meetingId } = await params;
+  const { code } = await searchParams;
+
+  // Server-only: session gate
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    const returnPath = `/check-in/${meetingId}${code ? `?code=${code}` : ""}`;
+    redirect(`/login?redirect=${encodeURIComponent(returnPath)}`);
+  }
+
+  const parsedMeetingId = parseInt(meetingId);
+  if (isNaN(parsedMeetingId)) {
+    return <p className="p-6 text-center">Invalid meeting link.</p>;
+  }
+
+  // Server-only: fetch the meeting to show its title
+  const meeting = await prisma.meeting.findUnique({ where: { id: parsedMeetingId } });
+  if (!meeting) {
+    return <p className="p-6 text-center">Meeting not found.</p>;
+  }
+
+  // Hand off to the Client Component for the interactive part
+  return (
+    <div className="container mx-auto max-w-md p-6">
+      <CheckInForm
+        meetingId={parsedMeetingId}
+        meetingTitle={meeting.title}
+        initialCode={code ?? ""}
+      />
+    </div>
+  );
+}

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { syncUserToDb } from "@/lib/auth/sync-user";
 import { redirect } from "next/navigation";
 
+
 export async function signUp(formData: FormData) {
     const email = formData.get('email') as string;
     const password = formData.get('password') as string;

--- a/src/app/meetings/[meetingId]/attendance/AttendanceToggle.tsx
+++ b/src/app/meetings/[meetingId]/attendance/AttendanceToggle.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Attendance } from "@/types/dashboard";
+import { useEffect, useState } from "react";
+
+const STATUSES = ["REGISTERED", "PRESENT", "ABSENT"] as const;
+
+interface AttendanceToggleProps {
+    meetingId: number;
+    meetingTitle: string;
+}
+
+export function AttendanceToggle({ meetingId, meetingTitle }: AttendanceToggleProps) {
+    const [records, setRecords] = useState<Attendance[]>([])
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [savingId, setSavingId] = useState<number | null>(null);
+
+    useEffect(() => {
+        async function load() {
+            setIsLoading(true);
+            setError(null);
+            try {
+                const res = await fetch(`/api/attendance?meetingId=${meetingId}`);
+                if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+                setRecords(await res.json());
+            } catch {
+                setError("Could not load attendance.");
+            } finally {
+                setIsLoading(false);
+            }
+        }
+        load();
+    }, [meetingId])
+
+    async function updateStatus(recordId: number, status: string) {
+        setSavingId(recordId);
+        setError(null);
+        try {
+            const res = await fetch(`/api/attendance/${recordId}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ status }),
+            });
+            if (!res.ok) throw new Error("Save failed");
+            const updated = await res.json();
+            // Apply change locally only after the server confirms it
+            setRecords((prev) => 
+                prev.map((r) => (r.id === recordId ? { ...r, status: updated.status } : r))
+            );
+        } catch {
+            setError("Could not save that change");
+        } finally {
+            setSavingId(null);
+        }
+    }
+
+    if (isLoading) return <p className="text-sm text-muted-foreground">Loading attendance...</p>
+    if (error && records.length === 0) return <p className="text-sm text-destructive">{error}</p>
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Take attendance</CardTitle>
+                <CardDescription>{meetingTitle}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                {records.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No attendees yet for this meeting.</p>
+                ) : (
+                    records.map((record) => (
+                        <div key={record.id} className="flex items-center justify-between border-b py-2">
+                            <div>
+                                <div className="font-medium">{record.user.name || "N/A"}</div>
+                                <div className="text-sm text-muted-foreground">{record.user.email}</div>
+                            </div>
+                            <div className="flex gap-1">
+                                {STATUSES.map((s) => (
+                                    <Button
+                                        key={s}
+                                        size="sm"
+                                        variant={record.status === s ? "default" : "outline"}
+                                        disabled={savingId === record.id}
+                                        onClick={() => updateStatus(record.id, s)}
+                                    >
+                                        {s.charAt(0) + s.slice(1).toLowerCase()}
+                                    </Button>
+                                ))}
+                            </div>
+                        </div>
+                    ))
+                )}
+                {error && records.length > 0 && (
+                    <p className="text-sm text-destructive">{error}</p>
+                )}
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/app/meetings/[meetingId]/attendance/page.tsx
+++ b/src/app/meetings/[meetingId]/attendance/page.tsx
@@ -1,0 +1,34 @@
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { AttendanceToggle } from "./AttendanceToggle";
+
+export default async function MeetingAttendancePage({
+    params,
+}: {
+    params: Promise<{ meetingId: string }>
+}) {
+    const { meetingId } = await params;
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+        redirect("/login");
+    }
+
+    const parsedMeetingId = parseInt(meetingId);
+    if (isNaN(parsedMeetingId)) {
+        return <p className="p-6 text-center">Invalid meeting.</p>
+    }
+
+    const meeting = await prisma.meeting.findUnique({ where: { id: parsedMeetingId } });
+    if (!meeting) {
+        return <p className="p-6 text-center">Meeting not found.</p>
+    }
+
+    return (
+        <div className="container mx-auto max-w-2xl p-6">
+            <AttendanceToggle meetingId={parsedMeetingId} meetingTitle={meeting.title} />
+        </div>
+    )
+}

--- a/src/app/meetings/[meetingId]/check-in-display/CheckInQR.tsx
+++ b/src/app/meetings/[meetingId]/check-in-display/CheckInQR.tsx
@@ -29,7 +29,7 @@ export function CheckInQR({ meetingTitle, code, path } : CheckInQRProps) {
                     <QRCodeSVG value={url} size={240} />
                 ) : (
                     <div className="h-[240px] w-[240px] animate-pulse rounded-md bg-muted" />
-                )};
+                )}
                 <div className="text-center">
                     <p className="text-sm text-muted-foreground">Or enter this code:</p>
                     <p className="text-3xl font-bold tracking-widest">{code}</p>

--- a/src/app/meetings/[meetingId]/check-in-display/CheckInQR.tsx
+++ b/src/app/meetings/[meetingId]/check-in-display/CheckInQR.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { QRCodeSVG } from "qrcode.react";
+import { useEffect, useState } from "react";
+
+interface CheckInQRProps {
+    meetingTitle: string;
+    code: string;
+    path: string;
+}
+
+export function CheckInQR({ meetingTitle, code, path } : CheckInQRProps) {
+    const [url, setUrl] = useState<string | null>(null);
+
+    useEffect(() => {
+        //window only exists in the browser - build hte absolute URL after mount
+        setUrl(`${window.location.origin}${path}`);
+    }, [path]);
+
+    return (
+        <Card>
+            <CardHeader className="text-cetner">
+                <CardTitle>Check in</CardTitle>
+                <CardDescription>{meetingTitle}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col items-center space-y-6">
+                {url ? (
+                    <QRCodeSVG value={url} size={240} />
+                ) : (
+                    <div className="h-[240px] w-[240px] animate-pulse rounded-md bg-muted" />
+                )};
+                <div className="text-center">
+                    <p className="text-sm text-muted-foreground">Or enter this code:</p>
+                    <p className="text-3xl font-bold tracking-widest">{code}</p>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/app/meetings/[meetingId]/check-in-display/page.tsx
+++ b/src/app/meetings/[meetingId]/check-in-display/page.tsx
@@ -1,0 +1,39 @@
+import { generateCheckInCode } from "@/lib/attendance/check-in-code";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { CheckInQR } from "./CheckInQR";
+
+export default async function CheckInDisplayPage({
+    params,
+} : {
+    params: Promise<{ meetingId: string }>;
+}) {
+    const { meetingId } = await params;
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+        redirect("/login");
+    }
+
+    const parsedMeetingId = parseInt(meetingId);
+    if (isNaN(parsedMeetingId)) {
+        return <p className="p-6 text-center">Invalid meeting.</p>
+    }
+
+    const meeting = await prisma.meeting.findUnique({ where: { id: parsedMeetingId } });
+    if (!meeting) {
+        return <p className="p-6 text-center">Meeting not found.</p>
+    }
+
+    //Server-only: generate the code with the secret. Only 'code' + 'path' cross to the client.
+    const code = generateCheckInCode(parsedMeetingId);
+    const path = `/check-in/${parsedMeetingId}?code=${code}`;
+
+    return (
+        <div className="container mx-auto max-w-md p-6">
+            <CheckInQR meetingTitle={meeting.title} code={code} path={path} />
+        </div>
+    );
+}

--- a/src/components/MeetingsTable.tsx
+++ b/src/components/MeetingsTable.tsx
@@ -18,7 +18,8 @@ import {
 } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { useRouter } from "next/navigation"
-import React, { useState } from "react"
+import Link from "next/link"
+import React, { useEffect, useState } from "react"
 import {
   Modal,
   ModalHeader,
@@ -46,6 +47,7 @@ const MEETING_TYPES = [
 interface NewMeeting {
   title: string;
   type: string;
+  teamId: string;
   scheduledAt: string;
   description: string;
   location: string;
@@ -56,6 +58,7 @@ interface NewMeeting {
 const emptyMeeting: NewMeeting = {
   title: "",
   type: "",
+  teamId: "none",
   scheduledAt: "",
   description: "",
   location: "",
@@ -69,6 +72,23 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
   const [newMeeting, setNewMeeting] = useState<NewMeeting>(emptyMeeting);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [teams, setTeams] = useState<{ id: number; name: string }[]>([]);
+
+  useEffect(() => {
+    if (!showAddModal) return;
+    if (teams.length > 0) return;
+    async function loadTeams() {
+      try {
+        const res = await fetch(`/api/teams`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setTeams(data.map((t: { id: number; name: string }) => ({ id: t.id, name: t.name })));
+      } catch {
+
+      }  
+    }
+    loadTeams();
+  }, [showAddModal, teams.length]);
 
   const getStatusBadge = (meeting: Meeting) => {
     if (meeting.endedAt) return <Badge variant="secondary">Completed</Badge>
@@ -108,6 +128,7 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
         body: JSON.stringify({
           title: newMeeting.title,
           type: newMeeting.type,
+          teamId: newMeeting.teamId === "none"? null : Number(newMeeting.teamId),
           scheduledAt: new Date(newMeeting.scheduledAt).toISOString(),
           description: newMeeting.description || null,
           location: newMeeting.location || null,
@@ -154,11 +175,12 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
               <TableHead>Scheduled</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Attendance</TableHead>
+              <TableHead>Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {meetings.length === 0 ? (
-              <TableEmptyState colSpan={7} message="No meetings scheduled yet." />
+              <TableEmptyState colSpan={8} message="No meetings scheduled yet." />
             ) : (
             meetings.map((meeting) => (
               <TableRow key={meeting.id}>
@@ -173,6 +195,17 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
                 <TableCell>
                   <div className="text-sm">
                     {meeting.attendance.filter(a => a.status === 'PRESENT').length} / {meeting.attendance.length}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-3">
+                    <Link href={`/meetings/${meeting.id}/attendance`} className="text-sm text-primary underline">
+                      Attendance
+                    </Link>
+                    <Link href={`/meetings/${meeting.id}/check-in-display`} className="text-sm text-primary underline">
+                      QR Code
+                    </Link>
+
                   </div>
                 </TableCell>
               </TableRow>
@@ -201,6 +234,15 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
                   value: t,
                   label: t.replace(/_/g, " "),
                 }))}
+              />
+              <ModalDropdown 
+                label="Team (optional)"
+                value={newMeeting.teamId}
+                onChange={(e) => setNewMeeting((prev) => ({ ...prev, teamId: e.target.value }))}
+                options={[
+                  { value: "none", label: "General - all members" },
+                  ...teams.map((t) => ({ value: String(t.id), label: t.name })),
+                ]}
               />
               <label className="block text-sm font-medium">Scheduled at</label>
               <input

--- a/src/lib/attendance/check-in-code.ts
+++ b/src/lib/attendance/check-in-code.ts
@@ -1,0 +1,30 @@
+import { createHmac } from "crypto";
+
+/**
+ * Generates a check in code for a meeting to mark attendance.
+ * 
+ * @param meetingId the meeting id.
+ */
+export function generateCheckInCode(meetingId: number) : string {
+    const secret = process.env.CHECKIN_SECRET;
+    if(!secret) {
+        throw new Error("CHECKIN_SECRET is not set");
+    }
+    
+    const fullHash = createHmac("sha256", secret)
+        .update(String(meetingId))
+        .digest("hex");
+
+    return fullHash.slice(0, 6).toUpperCase();
+}
+
+/**
+ * Verifys the check-in code for a specific meeting to mark attendance.
+ * 
+ * @param meetingId the meeting id
+ * @param code the check-in code
+ */
+export function verifyCheckInCode(meetingId: number, code: string): boolean {
+    const expected = generateCheckInCode(meetingId);
+    return expected === code.trim().toUpperCase();
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { generateCheckInCode } from "../attendance/check-in-code";
 
 export async function createClient() {
     const cookieStore = await cookies();


### PR DESCRIPTION
Closing #54  — delivered the officer manual toggle from the original ACs, plus a full mobile self-check-in system on top. Shipped:

Officer toggle (/meetings/[id]/attendance): per-row Registered/Present/Absent, saves immediately via the existing PUT route, per-row save state. Satisfies the original ACs. QR / code self-check-in: stateless HMAC check-in codes (lib/attendance/check-in-code.ts, no schema change), POST /api/attendance/check-in deriving identity from the Supabase session and upserting to PRESENT, member check-in page, officer QR display (/meetings/[id]/check-in-display). Auto-registration on meeting creation: meeting POST now pre-registers the expected roster as REGISTERED — the meeting's team if teamId is set, otherwise all members. createMany + skipDuplicates. Cascade delete handles teardown. Team picker added to the Add Meeting modal, which activates the team-scoped registration branch.

Verified end-to-end: both registration branches, QR round-trip, officer toggle persistence, cascade delete.
Deferred (not blocking): role-gating these officer pages (unblocks #12 ), login redirect bounce-back, rotating check-in code, and officer "add walk-in attendee" (Piece C).