### PR TITLE
Built User Account Settings Page

### DIFF
--- a/src/app/MemberDashboard.tsx
+++ b/src/app/MemberDashboard.tsx
@@ -112,15 +112,20 @@ export async function MemberDashboard({ user }: { user: User }) {
 
             {/* Logout */}
             <CardFooter className="px-0">
-                <form>
-                    <SubmitButton 
-                    formAction={logOut} 
-                    className="text-sm px-3 py-1.5 rounded-md bg-[rgb(76,111,78)] text-white hover:opacity-90 transition"
-                    pendingLabel="Logging Out..."
-                    >
-                        Log out
-                    </SubmitButton>
-                </form>
+                <div className="flex items-center gap-2">
+                    <Button asChild variant="outline" className="text-sm px-3 py-1.5 rounded-md">
+                        <Link href="/settings">Settings</Link>
+                    </Button>
+                    <form>
+                        <SubmitButton 
+                        formAction={logOut} 
+                        className="text-sm px-3 py-1.5 rounded-md bg-[rgb(76,111,78)] text-white hover:opacity-90 transition"
+                        pendingLabel="Logging Out..."
+                        >
+                            Log out
+                        </SubmitButton>
+                    </form>
+                </div>
             </CardFooter>
             
         </div>

--- a/src/app/OfficerDashboard.tsx
+++ b/src/app/OfficerDashboard.tsx
@@ -10,6 +10,7 @@ import { SubmitButton } from "@/components/SubmitButton";
 import { AttendanceStatus } from "@prisma/client";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 export async function OfficerDashboard() {
     const emptyData = {
@@ -104,15 +105,20 @@ export async function OfficerDashboard() {
             <h1 className="text-3xl font-bold">FirstByte Dashboard</h1>
             <p className="text-muted-foreground">Participation and engagement tracking</p>
           </div>
-          <form>
-            <SubmitButton 
+          <div className="flex items-center gap-2">
+            <Button asChild variant="outline" className="text-sm px-3 py-1.5 rounded-md">
+                <Link href="/settings">Settings</Link>
+            </Button>
+            <form>
+                <SubmitButton 
                 formAction={logOut} 
                 className="text-sm px-3 py-1.5 rounded-md bg-[rgb(76,111,78)] text-white hover:opacity-90 transition"
                 pendingLabel="Logging Out..."
                 >
-                Log out
-            </SubmitButton>
-          </form>
+                    Log out
+                </SubmitButton>
+            </form>
+          </div>
           {dbUnavailable && (
             <div className="rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-900">
               Could not load database data right now. Showing an empty dashboard until the connection is restored.

--- a/src/app/settings/NameForm.tsx
+++ b/src/app/settings/NameForm.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useActionState } from "react"
+import { updateName } from "./actions"
+import { Input } from "@/components/ui/input"
+import { SubmitButton } from "@/components/SubmitButton"
+
+export function NameForm({ currentName }: { currentName: string | null }) {
+    const [state, formAction] = useActionState(updateName, {})
+
+    return (
+        <form action={formAction} className="space-y-3">
+            <Input name="name" defaultValue={currentName ?? ""} />
+            <SubmitButton pendingLabel="Saving...">Save</SubmitButton>
+            {state?.error && <p className="text-sm text-destructive">{state.error}</p>}
+            {state?.success && <p className="text-sm text-muted-foreground">Name updated</p>}
+        </form>
+    )
+}

--- a/src/app/settings/PasswordForm.tsx
+++ b/src/app/settings/PasswordForm.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { SubmitButton } from "@/components/SubmitButton"
+import { Input } from "@/components/ui/input"
+import { useActionState } from "react"
+import { updatePassword } from "./actions"
+
+export function PasswordForm() {
+    const [state, formAction] = useActionState(updatePassword, {})
+
+    return (
+        <form action={formAction} className="space-y-3">
+            <Input type="password" name="currentPassword" placeholder="Current password" />
+            <Input type="password" name="newPassword" placeholder="New password" />
+            <Input type="password" name="confirmPassword" placeholder="Confirm new password" />
+            <SubmitButton pendingLabel="Updating...">Update password</SubmitButton>
+            {state?.error && <p className="text-sm text-destructive">{state.error}</p>}
+            {state?.success && <p className="text-sm text-muted-foreground">Password updated</p>}
+        </form>
+    )
+}

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -1,0 +1,55 @@
+'use server'
+
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
+
+type ActionResult = { success?: boolean; error?: string }
+
+export async function updateName(prevState: ActionResult, formData: FormData): Promise<ActionResult> {
+    const name = (formData.get('name') as string ?? "").trim()
+    if (!name) return { error: 'Name cannot be empty' }
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.email) return { error: 'Not authenticated' }
+    
+    const { error: authError } = await supabase.auth.updateUser({ data: { full_name: name } })
+    if (authError) return { error: authError.message };
+
+    try {
+        await prisma.user.update({ where: { email: user.email }, data: { name }})
+    } catch (error) {
+        return { error: 'Failed to update name' }
+    }
+
+    revalidatePath('/settings')
+    return { success: true }
+    
+}
+
+export async function updatePassword(prevState: ActionResult, formData: FormData): Promise<ActionResult> {
+    const currentPassword = formData.get("currentPassword") as string;
+    const newPassword = formData.get("newPassword") as string;
+    const confirmPassword = formData.get("confirmPassword") as string;
+
+    if (!(currentPassword && newPassword && confirmPassword)) {
+        return { error: 'All fields are required.'}
+    } else if (newPassword !== confirmPassword) {
+        return { error: 'New passwords do not match.'}
+    } else if (newPassword.length < 6) {
+        return { error: 'Password must be at least 6 characters.'}
+    }
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.email) return { error: 'Not authenticated' }
+
+    const { error } = await supabase.auth.updateUser({
+        current_password: currentPassword,
+        password: newPassword,
+    })
+    if (error) return { error: error.message }
+
+    return { success: true };
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getCurrentUser } from "@/lib/auth/getCurrentUser";
+import { redirect } from "next/navigation";
+import { NameForm } from "./NameForm";
+import { PasswordForm } from "./PasswordForm";
+import { BackLink } from "@/components/BackLink";
+
+export default async function UserSettingsPage() {
+    const user = await getCurrentUser();
+    if (!user) redirect('/login')
+    
+    return (
+        <div className="container mx-auto p-6 space-y-6">
+            <BackLink />
+            <Card>
+                <CardHeader>
+                    <CardTitle>Profile</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <NameForm currentName={user.name} />
+                </CardContent>
+            </Card>
+            <Card>
+                <CardHeader>
+                    <CardTitle>Password</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <PasswordForm />
+                </CardContent>
+            </Card>
+        </div>
+    );
+}


### PR DESCRIPTION
## ✅ Complete

Settings page live at `/settings`, accessible to all logged-in users (edits are self-scoped — identity comes from the session, never the client).

**Built:**
- `UserSettingsPage` (Server Component) — loads current user via `getCurrentUser()`, redirects to `/login` if unauthenticated. Two cards: Profile + Password.
- `NameForm` + `updateName` action — writes Supabase Auth `full_name` metadata first, then the Prisma `name` row (order chosen so a Supabase failure never leaves the two out of sync). Rejects empty names. Revalidates `/settings`.
- `PasswordForm` + `updatePassword` action — `updateUser({ current_password, password })`, validates presence / match / min length server-side. No `email` in the call, no Prisma write (password lives only in Supabase Auth).
- Nav: Settings link in the `MemberDashboard` footer.

**No schema migration** — password lives in Supabase Auth, `name` is an existing column.

**Verified:** name persists across logout/login (confirms `syncUserToDb` early-return doesn't clobber), `full_name` metadata matches, wrong current password is rejected (dashboard "Require current password" toggle confirmed on), mismatch/short-password/empty-name errors surface, logged-out access redirects.