### PR TITLE
feat: add light/dark/system theming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.544.0",
         "next": "^15.5.22",
+        "next-themes": "^0.4.6",
         "qrcode.react": "^4.2.0",
         "radix-ui": "^1.6.2",
         "react": "19.1.0",
@@ -6771,6 +6772,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",
     "next": "^15.5.22",
+    "next-themes": "^0.4.6",
     "qrcode.react": "^4.2.0",
     "radix-ui": "^1.6.2",
     "react": "19.1.0",

--- a/src/app/MemberDashboard.tsx
+++ b/src/app/MemberDashboard.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { MeetingStatusBadge } from "@/components/MeetingStatusBadge";
 import { SubmitButton } from "@/components/SubmitButton";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { SuggestionBoxLink } from "@/components/SuggestionBoxLink";
 import { TWO_HOURS_MS } from "@/lib/attendance/cutoff";
 
@@ -191,6 +192,7 @@ export async function MemberDashboard({ user }: { user: User }) {
       {/* Logout */}
       <CardFooter className="px-0">
         <div className="flex items-center gap-2">
+          <ThemeToggle />
           <Button
             asChild
             variant="outline"
@@ -201,7 +203,8 @@ export async function MemberDashboard({ user }: { user: User }) {
           <form>
             <SubmitButton
               formAction={logOut}
-              className="text-sm px-3 py-1.5 rounded-md bg-[rgb(76,111,78)] text-white hover:opacity-90 transition"
+              variant="brand"
+              className="text-sm px-3 py-1.5 rounded-md"
               pendingLabel="Logging Out..."
             >
               Log out

--- a/src/app/OfficerDashboard.tsx
+++ b/src/app/OfficerDashboard.tsx
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/prisma";
 import type { Feedback, Meeting, Team, User } from "@/types/dashboard";
 import { logOut } from "./login/actions";
 import { SubmitButton } from "@/components/SubmitButton";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { AttendanceStatus } from "@prisma/client";
 import {
   Card,
@@ -17,6 +18,7 @@ import {
 } from "@/components/ui/card";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { Banner } from "@/components/ui/banner";
 import { redactAnonymous } from "@/lib/feedback/redactAnonymous";
 import { SuggestionBoxLink } from "@/components/SuggestionBoxLink";
 
@@ -126,6 +128,7 @@ export async function OfficerDashboard() {
         </p>
       </div>
       <div className="flex items-center gap-2">
+        <ThemeToggle />
         <Button
           asChild
           variant="outline"
@@ -136,7 +139,8 @@ export async function OfficerDashboard() {
         <form>
           <SubmitButton
             formAction={logOut}
-            className="text-sm px-3 py-1.5 rounded-md bg-[rgb(76,111,78)] text-white hover:opacity-90 transition"
+            variant="brand"
+            className="text-sm px-3 py-1.5 rounded-md"
             pendingLabel="Logging Out..."
           >
             Log out
@@ -144,10 +148,10 @@ export async function OfficerDashboard() {
         </form>
       </div>
       {dbUnavailable && (
-        <div className="rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-900">
+        <Banner variant="warning">
           Could not load database data right now. Showing an empty dashboard
           until the connection is restored.
-        </div>
+        </Banner>
       )}
 
       <div className="grid gap-6 [*&>*]:min-w-0">

--- a/src/app/attendance/MemberAttendanceView.tsx
+++ b/src/app/attendance/MemberAttendanceView.tsx
@@ -2,6 +2,7 @@ import { BackLink } from "@/components/BackLink";
 import { MemberAttendanceTable } from "@/components/MemberAttendanceTable";
 import { MemberStatusFilter } from "@/components/MemberStatusFilter";
 import { PaginationControls } from "@/components/PaginationControls";
+import { Banner } from "@/components/ui/banner";
 import { getAttendanceCutoff } from "@/lib/attendance/cutoff";
 import {
   keyToWhere,
@@ -111,10 +112,10 @@ export async function MemberAttendanceView({
   return (
     <div className="container mx-auto p-6">
       {dbUnavailable && (
-        <div className="rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-900 mb-4">
+        <Banner variant="warning" className="mb-4">
           Could not load your attendance right now. Showing an empty view until
           the connection is restored.
-        </div>
+        </Banner>
       )}
       <BackLink />
       <div className="mt-4 mb-4">

--- a/src/app/attendance/OfficerAttendanceView.tsx
+++ b/src/app/attendance/OfficerAttendanceView.tsx
@@ -3,6 +3,7 @@ import { BackLink } from "@/components/BackLink";
 import { PaginationControls } from "@/components/PaginationControls";
 import { SearchInput } from "@/components/SearchInput";
 import { StatusFilter } from "@/components/StatusFilter";
+import { Banner } from "@/components/ui/banner";
 import { requireOfficer } from "@/lib/auth/requireOfficer";
 import { getPagination } from "@/lib/pagination";
 import { prisma } from "@/lib/prisma";
@@ -98,10 +99,10 @@ export async function OfficerAttendanceView({
   return (
     <div className="container mx-auto p-6">
       {dbUnavailable && (
-        <div className="rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-900 mb-4">
+        <Banner variant="warning" className="mb-4">
           Could not load attendance right now. Showing an empty view until the
           connection is restored.
-        </div>
+        </Banner>
       )}
       <BackLink />
       <div className="mt-4 mb-4">

--- a/src/app/check-in/[meetingId]/CheckInForm.tsx
+++ b/src/app/check-in/[meetingId]/CheckInForm.tsx
@@ -57,7 +57,9 @@ export function CheckInForm({
       </CardHeader>
       <CardContent className="space-y-4">
         {status === "success" ? (
-          <p className="text-center font-medium text-green-700">{message}</p>
+          <p className="text-center font-medium text-success-foreground">
+            {message}
+          </p>
         ) : (
           <>
             <div className="space-y-2">

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -8,6 +8,7 @@ import {
 import { requestPasswordReset } from "./actions";
 import { SubmitButton } from "@/components/SubmitButton";
 import { Input } from "@/components/ui/input";
+import { Banner } from "@/components/ui/banner";
 import { BackLink } from "@/components/BackLink";
 
 export default async function ForgotPasswordPage({
@@ -38,9 +39,9 @@ export default async function ForgotPasswordPage({
           ) : (
             <>
               {error && (
-                <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900">
+                <Banner variant="destructive" role="alert" className="mb-4">
                   {error}
-                </div>
+                </Banner>
               )}
               <form action={requestPasswordReset} className="space-y-3">
                 <Input name="email" type="email" placeholder="Email" required />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,6 +37,12 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-brand: var(--brand);
+  --color-brand-foreground: var(--brand-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -76,6 +82,12 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --brand: oklch(0.492 0.05 148.3);
+  --brand-foreground: oklch(0.985 0 0);
+  --warning: oklch(0.62 0.14 75);
+  --warning-foreground: oklch(0.35 0.09 70);
+  --success: oklch(0.55 0.13 150);
+  --success-foreground: oklch(0.3 0.08 150);
 }
 
 .dark {
@@ -110,6 +122,12 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --brand: oklch(0.68 0.075 148);
+  --brand-foreground: oklch(0.145 0 0);
+  --warning: oklch(0.75 0.15 80);
+  --warning-foreground: oklch(0.92 0.05 85);
+  --success: oklch(0.72 0.16 152);
+  --success-foreground: oklch(0.9 0.06 150);
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,11 +24,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/login/AuthForm.tsx
+++ b/src/app/login/AuthForm.tsx
@@ -9,6 +9,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Banner } from "@/components/ui/banner";
 import { signUp, logIn } from "./actions";
 import { GoogleButton } from "./GoogleButton";
 import { SubmitButton } from "@/components/SubmitButton";
@@ -34,9 +35,9 @@ export function AuthForm({ error }: { error?: string }) {
 
       <CardContent>
         {error && (
-          <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900">
+          <Banner variant="destructive" role="alert" className="mb-4">
             {error}
-          </div>
+          </Banner>
         )}
 
         <GoogleButton

--- a/src/app/meetings/[meetingId]/check-in-display/CheckInQR.tsx
+++ b/src/app/meetings/[meetingId]/check-in-display/CheckInQR.tsx
@@ -32,7 +32,11 @@ export function CheckInQR({ meetingTitle, code, path }: CheckInQRProps) {
       </CardHeader>
       <CardContent className="flex flex-col items-center space-y-6">
         {url ? (
-          <QRCodeSVG value={url} size={240} />
+          // QR stays black-on-white for scanner reliability; the explicit plate
+          // keeps it looking deliberate rather than stray on a dark background.
+          <div className="rounded-lg bg-white p-3">
+            <QRCodeSVG value={url} size={240} />
+          </div>
         ) : (
           <div className="h-[240px] w-[240px] animate-pulse rounded-md bg-muted" />
         )}

--- a/src/app/meetings/[meetingId]/feedback-display/FeedbackQR.tsx
+++ b/src/app/meetings/[meetingId]/feedback-display/FeedbackQR.tsx
@@ -31,7 +31,11 @@ export function FeedbackQR({ meetingTitle, path }: FeedbackQRProps) {
       </CardHeader>
       <CardContent className="flex flex-col items-center space-y-6">
         {url ? (
-          <QRCodeSVG className="mb-4" value={url} size={240} />
+          // QR stays black-on-white for scanner reliability; the explicit plate
+          // keeps it looking deliberate rather than stray on a dark background.
+          <div className="mb-4 rounded-lg bg-white p-3">
+            <QRCodeSVG value={url} size={240} />
+          </div>
         ) : (
           <div className="h-[240px] w-[240px] animate-pulse rounded-md bg-muted" />
         )}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Banner } from "@/components/ui/banner";
 import { SubmitButton } from "@/components/SubmitButton";
 import { updatePassword } from "./actions";
 
@@ -39,9 +40,9 @@ export default async function ResetPasswordPage({
         </CardHeader>
         <CardContent>
           {error && (
-            <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900">
+            <Banner variant="destructive" role="alert" className="mb-4">
               {error}
-            </div>
+            </Banner>
           )}
           <form action={updatePassword} className="space-y-3">
             <Input

--- a/src/components/FeedbackTable.tsx
+++ b/src/components/FeedbackTable.tsx
@@ -82,7 +82,7 @@ export function FeedbackTable({ feedback }: FeedbackTableProps) {
                     </div>
                   </TableCell>
                   <TableCell>
-                    <div className="text-yellow-500">
+                    <div className="text-warning">
                       {getRatingStars(item.rating)}
                     </div>
                   </TableCell>

--- a/src/components/MeetingStatusBadge.tsx
+++ b/src/components/MeetingStatusBadge.tsx
@@ -22,7 +22,9 @@ export function MeetingStatusBadge({
   if (now >= start)
     return (
       <Badge variant="default">
-        <span className="inline-block size-2 rounded-full bg-green-500 animate-pulse" />
+        {/* bg-current tracks the badge's own foreground, so the dot keeps contrast
+            against bg-primary in both themes (dark --primary is near-white). */}
+        <span className="inline-block size-2 rounded-full bg-current animate-pulse" />
         In Progress
       </Badge>
     );

--- a/src/components/MeetingsTable.tsx
+++ b/src/components/MeetingsTable.tsx
@@ -17,6 +17,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
@@ -242,13 +243,12 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
           <Modal onClose={closeModal}>
             <ModalHeader>Add New Meeting</ModalHeader>
             <form onSubmit={handleSubmit} className="flex flex-col space-y-3">
-              <input
+              <Input
                 type="text"
                 name="title"
                 value={newMeeting.title}
                 onChange={handleChange}
                 placeholder="Title"
-                className="border rounded p-2"
                 required
               />
               <ModalDropdown
@@ -273,12 +273,11 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
                 ]}
               />
               <label className="block text-sm font-medium">Scheduled at</label>
-              <input
+              <Input
                 type="datetime-local"
                 name="scheduledAt"
                 value={newMeeting.scheduledAt}
                 onChange={handleChange}
-                className="border rounded p-2"
                 required
               />
               <textarea
@@ -286,23 +285,21 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
                 value={newMeeting.description}
                 onChange={handleChange}
                 placeholder="Description (optional)"
-                className="border rounded p-2"
+                className="min-h-16 w-full min-w-0 resize-y rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 md:text-sm dark:bg-input/30"
               />
-              <input
+              <Input
                 type="text"
                 name="location"
                 value={newMeeting.location}
                 onChange={handleChange}
                 placeholder="Location (optional)"
-                className="border rounded p-2"
               />
-              <input
+              <Input
                 type="number"
                 name="maxCapacity"
                 value={newMeeting.maxCapacity}
                 onChange={handleChange}
                 placeholder="Max capacity (optional)"
-                className="border rounded p-2"
                 min={0}
               />
               <label className="flex items-center gap-2">
@@ -315,7 +312,7 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
                 Required
               </label>
 
-              {error && <p className="text-sm text-red-600">{error}</p>}
+              {error && <p className="text-sm text-destructive">{error}</p>}
 
               <div className="flex justify-end space-x-2 pt-2">
                 <ModalButton

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import * as React from "react";
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+
+const ORDER = ["light", "dark", "system"] as const;
+
+type Mode = (typeof ORDER)[number];
+
+const LABELS: Record<Mode, string> = {
+  light: "Light",
+  dark: "Dark",
+  system: "System",
+};
+
+const ICONS: Record<Mode, React.ComponentType<{ className?: string }>> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+};
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => setMounted(true), []);
+
+  // `theme` is undefined until next-themes reads storage on the client. Render a
+  // same-size placeholder so the button doesn't resize or swap icons on hydration.
+  if (!mounted) {
+    return (
+      <Button
+        variant="outline"
+        size="icon-sm"
+        className={className}
+        disabled
+        aria-hidden
+      />
+    );
+  }
+
+  const current = (ORDER.find((m) => m === theme) ?? "system") as Mode;
+  const next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
+  const Icon = ICONS[current];
+
+  return (
+    <Button
+      variant="outline"
+      size="icon-sm"
+      className={className}
+      onClick={() => setTheme(next)}
+      title={`Theme: ${LABELS[current]} — click for ${LABELS[next].toLowerCase()}`}
+      aria-label={`Theme: ${LABELS[current]}. Switch to ${LABELS[next].toLowerCase()}.`}
+    >
+      <Icon className="size-4" />
+      <span className="sr-only">Current theme: {LABELS[current]}</span>
+    </Button>
+  );
+}

--- a/src/components/UsersTable.tsx
+++ b/src/components/UsersTable.tsx
@@ -173,7 +173,7 @@ export function UsersTable({ users }: UsersTableProps) {
                   <TableCell>
                     <a
                       href={`mailto:${user.email}`}
-                      className="text-blue-600 hover:underline"
+                      className="text-primary hover:underline"
                     >
                       {user.email}
                     </a>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/components/ui/banner.tsx
+++ b/src/components/ui/banner.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+// Surfaces are built from an alpha tint of the tone rather than a fixed light
+// shade, so they composite over --background and stay legible in both themes.
+const bannerVariants = cva(
+  "rounded-md border px-4 py-3 text-sm [&_a]:underline [&_a]:underline-offset-4",
+  {
+    variants: {
+      variant: {
+        warning: "border-warning/40 bg-warning/10 text-warning-foreground",
+        destructive: "border-destructive/40 bg-destructive/10 text-destructive",
+        success: "border-success/40 bg-success/10 text-success-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "warning",
+    },
+  },
+);
+
+function Banner({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof bannerVariants>) {
+  return (
+    <div
+      data-slot="banner"
+      role="status"
+      className={cn(bannerVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Banner, bannerVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -16,6 +16,7 @@ const buttonVariants = cva(
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        brand: "bg-brand text-brand-foreground hover:bg-brand/90",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -53,7 +53,7 @@ function CardButton({ className, ...props }: React.ComponentProps<"button">) {
     <button
       data-slot="card-button"
       className={cn(
-        "bg-[rgb(76,111,78)] text-white px-4 py-2 rounded-md hover:opacity-90 transition",
+        "bg-brand text-brand-foreground px-4 py-2 rounded-md hover:bg-brand/90 transition",
         className,
       )}
       {...props}

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -2,6 +2,15 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+// Shared styling for the native <select> below. It stays a native control rather
+// than the Radix Select primitive because callers pass native onChange handlers
+// and rely on native form submission; `color-scheme` (set by next-themes) is what
+// darkens the OS-rendered option popup.
+const nativeControl =
+  "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30";
 
 interface ModalProps extends React.ComponentProps<"div"> {
   onClose?: () => void;
@@ -20,12 +29,15 @@ function Modal({
   return (
     <div
       data-slot="modal-overlay"
-      className="fixed inset-0 flex items-center justify-center bg-white/10 backdrop-blur-sm z-50"
+      className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-50"
       onClick={onClose}
     >
       <div
         data-slot="modal"
-        className={cn("bg-white rounded-lg shadow-lg p-6 w-96", className)}
+        className={cn(
+          "bg-popover text-popover-foreground border rounded-lg shadow-lg p-6 w-96",
+          className,
+        )}
         onClick={(e) => e.stopPropagation()} // prevent closing on inner clicks
         {...props}
       >
@@ -55,22 +67,20 @@ interface ModalFormProps {
 function ModalForm({ newUser, onChange, onSubmit, children }: ModalFormProps) {
   return (
     <form onSubmit={onSubmit} className="flex flex-col space-y-3">
-      <input
+      <Input
         type="text"
         name="name"
         value={newUser.name ?? ""}
         onChange={onChange}
         placeholder="Name"
-        className="border rounded p-2"
         required
       />
-      <input
+      <Input
         type="email"
         name="email"
         value={newUser.email}
         onChange={onChange}
         placeholder="Email"
-        className="border rounded p-2"
         required
       />
 
@@ -84,14 +94,14 @@ function ModalButton({
   className,
   ...props
 }: React.ComponentProps<"button"> & { variant?: "primary" | "cancel" }) {
-  const base = "px-3 py-1 rounded transition font-medium";
-
-  const styles =
-    variant === "primary"
-      ? "bg-[rgb(76,111,78)] text-white hover:opacity-90"
-      : "bg-gray-300 text-gray-800 hover:bg-gray-400";
-
-  return <button className={cn(base, styles, className)} {...props} />;
+  return (
+    <Button
+      variant={variant === "primary" ? "brand" : "secondary"}
+      size="sm"
+      className={className}
+      {...props}
+    />
+  );
 }
 
 interface ModalDropdownProps {
@@ -119,7 +129,7 @@ function ModalDropdown({
         <label className="block text-sm font-medium mb-1">{label}</label>
       )}
       <select
-        className="border rounded-md p-2 w-full"
+        className={nativeControl}
         value={value ?? ""}
         onChange={onChange}
         required={required}


### PR DESCRIPTION
The .dark token block and `dark` variant already existed in globals.css but nothing ever set the class, so the whole dark palette was dead code. This wires the JS half and fixes the surfaces that hardcoded light-mode colors.

Theme plumbing:
- Add next-themes, a client ThemeProvider passthrough, and suppressHydrationWarning on <html>. next-themes' own blocking script is the anti-flash mechanism; no hand-written inline script is needed.
- Add a cycling ThemeToggle (light -> dark -> system) to both dashboard headers, next to Settings/Log out. Guards on a mounted flag so the icon doesn't swap on hydration, and labels the next action for screen readers.

Tokens:
- Register --brand, --warning, and --success pairs in :root, .dark, AND the @theme inline map. The last is required in Tailwind v4 to emit the utilities at all -- without it bg-brand/text-warning silently generate nothing.
- --brand matches the logo's actual green, rgb(76,111,79). The old hardcoded classes said rgb(76,111,78).
- Add a `brand` Button variant so the green lives in one place instead of being passed as a className at four call sites.

Fixes:
- New shared Banner replaces six duplicated banner strings. Surfaces are an alpha tint of the tone (bg-warning/10) rather than a fixed light shade, so they composite over --background instead of becoming a near-white slab in dark. This is the dbUnavailable bug.
- modal.tsx was the worst offender and had not been reviewed: bg-white panel, a backwards bg-white/10 scrim, and a bg-gray-300 cancel button. Panel is now bg-popover, scrim bg-black/50, buttons delegate to Button variants.
- Bare "border rounded p-2" controls now use the Input primitive. The native <select> keeps native semantics with token classes rather than converting to the Radix Select, which would change the onChange contract at every call site; color-scheme darkens its OS-rendered popup.
- MeetingStatusBadge's pulse dot uses bg-current, not bg-green-500. Dark --primary is near-white, which green fails contrast against; bg-current tracks the badge's own foreground so it reads in both themes.
- QR codes stay black-on-white for scanner reliability, wrapped in an explicit white plate so they read as deliberate on a dark page.

The logo needed no change: it is transparent-backed FirstByte green, not dark ink, so it does not vanish on dark.

Verified: format:check, lint, typecheck, build all clean. First paint follows the OS with no stored preference, an explicit choice overrides it and persists across navigation, and there are no hydration warnings.