### PR TITLE
feat: open a detail overlay when an officer clicks a dashboard row

### DIFF
--- a/src/components/AttendanceStatusBadge.tsx
+++ b/src/components/AttendanceStatusBadge.tsx
@@ -1,0 +1,16 @@
+import { Badge } from "@/components/ui/badge";
+
+// Mirrors the AttendanceStatus enum in prisma/schema.prisma. Shared by the
+// attendance table and the meeting detail panel's roster so the two can't drift.
+export function AttendanceStatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case "PRESENT":
+      return <Badge variant="default">Present</Badge>;
+    case "ABSENT":
+      return <Badge variant="destructive">Absent</Badge>;
+    case "REGISTERED":
+      return <Badge variant="outline">Registered</Badge>;
+    default:
+      return <Badge variant="secondary">{status}</Badge>;
+  }
+}

--- a/src/components/AttendanceTable.tsx
+++ b/src/components/AttendanceTable.tsx
@@ -15,9 +15,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Attendance } from "@/types/dashboard";
 import { TableEmptyState } from "./ui/TableEmptyState";
+import { AttendanceStatusBadge } from "./AttendanceStatusBadge";
 
 interface AttendanceTableProps {
   attendance: Attendance[];
@@ -28,19 +28,6 @@ export function AttendanceTable({
   attendance,
   emptyMessage = "No attendance records yet.",
 }: AttendanceTableProps) {
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case "PRESENT":
-        return <Badge variant="default">Present</Badge>;
-      case "ABSENT":
-        return <Badge variant="destructive">Absent</Badge>;
-      case "REGISTERED":
-        return <Badge variant="outline">Registered</Badge>;
-      default:
-        return <Badge variant="secondary">{status}</Badge>;
-    }
-  };
-
   return (
     <Card>
       <CardHeader>
@@ -83,7 +70,9 @@ export function AttendanceTable({
                       </div>
                     </div>
                   </TableCell>
-                  <TableCell>{getStatusBadge(record.status)}</TableCell>
+                  <TableCell>
+                    <AttendanceStatusBadge status={record.status} />
+                  </TableCell>
                   <TableCell>
                     {record.checkedInAt
                       ? new Date(record.checkedInAt).toLocaleString()

--- a/src/components/FeedbackDetailSheet.tsx
+++ b/src/components/FeedbackDetailSheet.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { DetailSheet } from "@/components/ui/detail-sheet";
+import { DetailField, DetailGrid, DetailSection } from "@/components/ui/detail";
+import { formatDateTime } from "@/lib/format";
+import type { Feedback } from "@/types/dashboard";
+
+interface FeedbackDetailSheetProps {
+  feedback: Feedback | null;
+  onOpenChange: (open: boolean) => void;
+  onCloseAutoFocus: (event: Event) => void;
+}
+
+export function FeedbackDetailSheet({
+  feedback,
+  onOpenChange,
+  onCloseAutoFocus,
+}: FeedbackDetailSheetProps) {
+  return (
+    <DetailSheet
+      record={feedback}
+      onOpenChange={onOpenChange}
+      onCloseAutoFocus={onCloseAutoFocus}
+      title={(f) => `Feedback on ${f.meeting.title}`}
+      description={(f) => formatDateTime(f.createdAt) ?? "Feedback details"}
+    >
+      {(f) => (
+        <>
+          <DetailSection title="Author">
+            {/* Anonymous rows arrive here with author already stripped by
+                redactAnonymous in OfficerDashboard. Branching on isAnonymous
+                rather than on the (now null) author keeps the panel honest even
+                if the redaction ever changes shape. */}
+            {f.isAnonymous ? (
+              <p className="text-sm text-muted-foreground">
+                Submitted anonymously. The author is not recorded in this view.
+              </p>
+            ) : (
+              <DetailGrid>
+                <DetailField label="Name" value={f.author.name} />
+                {/* Passing null children lets DetailField apply its own empty
+                    state rather than restating the placeholder here. */}
+                <DetailField label="Email">
+                  {f.author.email ? (
+                    <a
+                      href={`mailto:${f.author.email}`}
+                      className="text-primary hover:underline"
+                    >
+                      {f.author.email}
+                    </a>
+                  ) : null}
+                </DetailField>
+              </DetailGrid>
+            )}
+          </DetailSection>
+
+          <DetailSection title="Response">
+            <DetailGrid>
+              <DetailField label="Rating">
+                {f.rating === null ? null : (
+                  <span>
+                    <span className="text-warning">
+                      {"★".repeat(f.rating)}
+                      {"☆".repeat(5 - f.rating)}
+                    </span>{" "}
+                    <span className="text-muted-foreground">
+                      ({f.rating} of 5)
+                    </span>
+                  </span>
+                )}
+              </DetailField>
+              <DetailField label="Category">
+                {f.category ? (
+                  <Badge variant="outline">{f.category}</Badge>
+                ) : null}
+              </DetailField>
+              <DetailField
+                label="Comment"
+                value={f.comment}
+                className="sm:col-span-2"
+              />
+              <DetailField label="Feedback ID" value={f.id} />
+              <DetailField
+                label="Submitted"
+                value={formatDateTime(f.createdAt)}
+              />
+            </DetailGrid>
+          </DetailSection>
+
+          <DetailSection title="Meeting">
+            <DetailGrid>
+              <DetailField label="Title" value={f.meeting.title} />
+              <DetailField
+                label="Scheduled"
+                value={formatDateTime(f.meeting.scheduledAt)}
+              />
+              <DetailField label="Meeting ID" value={f.meetingId} />
+            </DetailGrid>
+          </DetailSection>
+        </>
+      )}
+    </DetailSheet>
+  );
+}

--- a/src/components/FeedbackTable.tsx
+++ b/src/components/FeedbackTable.tsx
@@ -18,12 +18,18 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Feedback } from "@/types/dashboard";
 import { TableEmptyState } from "./ui/TableEmptyState";
+import { useDetailRow } from "@/hooks/useDetailRow";
+import { FeedbackDetailSheet } from "./FeedbackDetailSheet";
 
 interface FeedbackTableProps {
   feedback: Feedback[];
 }
 
 export function FeedbackTable({ feedback }: FeedbackTableProps) {
+  // Rows arrive already redacted by OfficerDashboard; the panel below renders
+  // straight from this prop so anonymous authors stay stripped.
+  const detail = useDetailRow<Feedback>();
+
   const getRatingStars = (rating: number | null) => {
     if (!rating) return "N/A";
     return "★".repeat(rating) + "☆".repeat(5 - rating);
@@ -58,7 +64,7 @@ export function FeedbackTable({ feedback }: FeedbackTableProps) {
               <TableEmptyState colSpan={7} message="No feedback yet." />
             ) : (
               feedback.map((item) => (
-                <TableRow key={item.id}>
+                <TableRow key={item.id} {...detail.getRowProps(item)}>
                   <TableCell>
                     {item.isAnonymous ? (
                       <div className="text-muted-foreground">Anonymous</div>
@@ -103,6 +109,11 @@ export function FeedbackTable({ feedback }: FeedbackTableProps) {
             )}
           </TableBody>
         </Table>
+        <FeedbackDetailSheet
+          feedback={detail.selected}
+          onOpenChange={detail.onOpenChange}
+          onCloseAutoFocus={detail.onCloseAutoFocus}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/MeetingDetailSheet.tsx
+++ b/src/components/MeetingDetailSheet.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { AttendanceStatusBadge } from "@/components/AttendanceStatusBadge";
+import { MeetingStatusBadge } from "@/components/MeetingStatusBadge";
+import { DetailSheet } from "@/components/ui/detail-sheet";
+import {
+  DetailEmpty,
+  DetailField,
+  DetailGrid,
+  DetailSection,
+} from "@/components/ui/detail";
+import { formatDateTime } from "@/lib/format";
+import type { Meeting } from "@/types/dashboard";
+
+interface MeetingDetailSheetProps {
+  meeting: Meeting | null;
+  onOpenChange: (open: boolean) => void;
+  onCloseAutoFocus: (event: Event) => void;
+}
+
+export function MeetingDetailSheet({
+  meeting,
+  onOpenChange,
+  onCloseAutoFocus,
+}: MeetingDetailSheetProps) {
+  return (
+    <DetailSheet
+      record={meeting}
+      onOpenChange={onOpenChange}
+      onCloseAutoFocus={onCloseAutoFocus}
+      title={(m) => m.title}
+      description={(m) => m.type.replace(/_/g, " ")}
+    >
+      {(m) => {
+        const present = m.attendance.filter(
+          (record) => record.status === "PRESENT",
+        ).length;
+
+        return (
+          <>
+            <DetailSection title="Overview">
+              <DetailGrid>
+                <DetailField
+                  label="Description"
+                  value={m.description}
+                  className="sm:col-span-2"
+                />
+                <DetailField label="Status">
+                  <MeetingStatusBadge scheduledAt={m.scheduledAt} />
+                </DetailField>
+                <DetailField label="Type">
+                  <Badge variant="outline">{m.type.replace(/_/g, " ")}</Badge>
+                </DetailField>
+                <DetailField label="Team" value={m.team?.name} />
+                <DetailField label="Location" value={m.location} />
+                <DetailField
+                  label="Required"
+                  value={m.isRequired ? "Yes" : "No"}
+                />
+                <DetailField label="Max capacity" value={m.maxCapacity} />
+                <DetailField label="Meeting ID" value={m.id} />
+              </DetailGrid>
+            </DetailSection>
+
+            <DetailSection title="Timing">
+              <DetailGrid>
+                <DetailField
+                  label="Scheduled"
+                  value={formatDateTime(m.scheduledAt)}
+                />
+                <DetailField
+                  label="Started"
+                  value={formatDateTime(m.startedAt)}
+                />
+                <DetailField label="Ended" value={formatDateTime(m.endedAt)} />
+                <DetailField
+                  label="Created"
+                  value={formatDateTime(m.createdAt)}
+                />
+              </DetailGrid>
+            </DetailSection>
+
+            <DetailSection
+              title={`Attendance (${present} of ${m.attendance.length} present)`}
+            >
+              {m.attendance.length === 0 ? (
+                <DetailEmpty>
+                  No attendance records for this meeting.
+                </DetailEmpty>
+              ) : (
+                <ul className="space-y-2">
+                  {m.attendance.map((record) => (
+                    <li
+                      key={record.id}
+                      className="space-y-2 rounded-md border p-3"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium">
+                            {record.user.name ?? record.user.email}
+                          </div>
+                          {record.user.name && (
+                            <div className="truncate text-xs text-muted-foreground">
+                              {record.user.email}
+                            </div>
+                          )}
+                        </div>
+                        <AttendanceStatusBadge status={record.status} />
+                      </div>
+                      <DetailGrid className="gap-2">
+                        <DetailField
+                          label="Checked in"
+                          value={formatDateTime(record.checkedInAt)}
+                        />
+                        <DetailField
+                          label="Checked out"
+                          value={formatDateTime(record.checkedOutAt)}
+                        />
+                        <DetailField
+                          label="Notes"
+                          value={record.notes}
+                          className="sm:col-span-2"
+                        />
+                      </DetailGrid>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </DetailSection>
+          </>
+        );
+      }}
+    </DetailSheet>
+  );
+}

--- a/src/components/MeetingsTable.tsx
+++ b/src/components/MeetingsTable.tsx
@@ -30,6 +30,8 @@ import {
 import { Meeting } from "@/types/dashboard";
 import { TableEmptyState } from "./ui/TableEmptyState";
 import { MeetingStatusBadge } from "./MeetingStatusBadge";
+import { useDetailRow } from "@/hooks/useDetailRow";
+import { MeetingDetailSheet } from "./MeetingDetailSheet";
 
 interface MeetingsTableProps {
   meetings: Meeting[];
@@ -75,6 +77,7 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [teams, setTeams] = useState<{ id: number; name: string }[]>([]);
+  const detail = useDetailRow<Meeting>();
 
   useEffect(() => {
     if (!showAddModal) return;
@@ -189,7 +192,7 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
               />
             ) : (
               meetings.map((meeting) => (
-                <TableRow key={meeting.id}>
+                <TableRow key={meeting.id} {...detail.getRowProps(meeting)}>
                   <TableCell>{meeting.title}</TableCell>
                   <TableCell>
                     <Badge variant="outline">
@@ -239,6 +242,11 @@ export function MeetingsTable({ meetings }: MeetingsTableProps) {
             )}
           </TableBody>
         </Table>
+        <MeetingDetailSheet
+          meeting={detail.selected}
+          onOpenChange={detail.onOpenChange}
+          onCloseAutoFocus={detail.onCloseAutoFocus}
+        />
         {showAddModal && (
           <Modal onClose={closeModal}>
             <ModalHeader>Add New Meeting</ModalHeader>

--- a/src/components/TeamDetailSheet.tsx
+++ b/src/components/TeamDetailSheet.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { DetailSheet } from "@/components/ui/detail-sheet";
+import {
+  DetailEmpty,
+  DetailField,
+  DetailGrid,
+  DetailSection,
+} from "@/components/ui/detail";
+import { formatDateTime } from "@/lib/format";
+import type { Team } from "@/types/dashboard";
+
+interface TeamDetailSheetProps {
+  team: Team | null;
+  onOpenChange: (open: boolean) => void;
+  onCloseAutoFocus: (event: Event) => void;
+}
+
+export function TeamDetailSheet({
+  team,
+  onOpenChange,
+  onCloseAutoFocus,
+}: TeamDetailSheetProps) {
+  return (
+    <DetailSheet
+      record={team}
+      onOpenChange={onOpenChange}
+      onCloseAutoFocus={onCloseAutoFocus}
+      title={(t) => t.name}
+      description={() => "Team details"}
+    >
+      {(t) => (
+        <>
+          <DetailSection title="Overview">
+            <DetailGrid>
+              <DetailField
+                label="Description"
+                value={t.description}
+                className="sm:col-span-2"
+              />
+              <DetailField label="Status">
+                <Badge variant={t.isActive ? "default" : "secondary"}>
+                  {t.isActive ? "Active" : "Inactive"}
+                </Badge>
+              </DetailField>
+              <DetailField label="Team ID" value={t.id} />
+              <DetailField
+                label="Created"
+                value={formatDateTime(t.createdAt)}
+              />
+              <DetailField
+                label="Last updated"
+                value={formatDateTime(t.updatedAt)}
+              />
+            </DetailGrid>
+          </DetailSection>
+
+          <DetailSection title={`Members (${t.members.length})`}>
+            {t.members.length === 0 ? (
+              <DetailEmpty>No members on this team yet.</DetailEmpty>
+            ) : (
+              <ul className="space-y-2">
+                {t.members.map((member) => (
+                  <li
+                    key={member.user.email}
+                    className="flex items-center justify-between gap-2 rounded-md border p-3"
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">
+                        {member.user.name ?? member.user.email}
+                      </div>
+                      {member.user.name && (
+                        <div className="truncate text-xs text-muted-foreground">
+                          {member.user.email}
+                        </div>
+                      )}
+                    </div>
+                    <Badge variant="outline">{member.role}</Badge>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </DetailSection>
+        </>
+      )}
+    </DetailSheet>
+  );
+}

--- a/src/components/TeamsTable.tsx
+++ b/src/components/TeamsTable.tsx
@@ -18,12 +18,16 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Team } from "@/types/dashboard";
 import { TableEmptyState } from "./ui/TableEmptyState";
+import { useDetailRow } from "@/hooks/useDetailRow";
+import { TeamDetailSheet } from "./TeamDetailSheet";
 
 interface TeamsTableProps {
   teams: Team[];
 }
 
 export function TeamsTable({ teams }: TeamsTableProps) {
+  const detail = useDetailRow<Team>();
+
   return (
     <Card>
       <CardHeader>
@@ -49,7 +53,7 @@ export function TeamsTable({ teams }: TeamsTableProps) {
               />
             ) : (
               teams.map((team) => (
-                <TableRow key={team.id}>
+                <TableRow key={team.id} {...detail.getRowProps(team)}>
                   <TableCell>{team.name}</TableCell>
                   <TableCell>{team.description || "N/A"}</TableCell>
                   <TableCell>
@@ -75,6 +79,11 @@ export function TeamsTable({ teams }: TeamsTableProps) {
             )}
           </TableBody>
         </Table>
+        <TeamDetailSheet
+          team={detail.selected}
+          onOpenChange={detail.onOpenChange}
+          onCloseAutoFocus={detail.onCloseAutoFocus}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/UserDetailSheet.tsx
+++ b/src/components/UserDetailSheet.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { DetailSheet } from "@/components/ui/detail-sheet";
+import {
+  DetailEmpty,
+  DetailField,
+  DetailGrid,
+  DetailSection,
+} from "@/components/ui/detail";
+import { formatDateTime } from "@/lib/format";
+import type { User } from "@/types/dashboard";
+
+interface UserDetailSheetProps {
+  user: User | null;
+  onOpenChange: (open: boolean) => void;
+  onCloseAutoFocus: (event: Event) => void;
+}
+
+export function UserDetailSheet({
+  user,
+  onOpenChange,
+  onCloseAutoFocus,
+}: UserDetailSheetProps) {
+  return (
+    <DetailSheet
+      record={user}
+      onOpenChange={onOpenChange}
+      onCloseAutoFocus={onCloseAutoFocus}
+      title={(u) => u.name ?? u.email}
+      description={() => "User details"}
+    >
+      {(u) => (
+        <>
+          <DetailSection title="Account">
+            <DetailGrid>
+              <DetailField label="Name" value={u.name} />
+              <DetailField label="Email">
+                <a
+                  href={`mailto:${u.email}`}
+                  className="text-primary hover:underline"
+                >
+                  {u.email}
+                </a>
+              </DetailField>
+              <DetailField label="User ID" value={u.id} />
+              <DetailField label="Joined" value={formatDateTime(u.createdAt)} />
+              <DetailField
+                label="Last updated"
+                value={formatDateTime(u.updatedAt)}
+              />
+            </DetailGrid>
+          </DetailSection>
+
+          <DetailSection
+            title={`Teams (${u.teamMemberships.length})`}
+            aria-label="Team memberships"
+          >
+            {u.teamMemberships.length === 0 ? (
+              <DetailEmpty>Not a member of any team.</DetailEmpty>
+            ) : (
+              <ul className="space-y-2">
+                {u.teamMemberships.map((membership) => (
+                  <li
+                    key={membership.id}
+                    className="flex items-center justify-between gap-2 rounded-md border p-3"
+                  >
+                    <span className="min-w-0 truncate text-sm font-medium">
+                      {membership.team.name}
+                    </span>
+                    <Badge variant="secondary">{membership.role}</Badge>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </DetailSection>
+        </>
+      )}
+    </DetailSheet>
+  );
+}

--- a/src/components/UsersTable.tsx
+++ b/src/components/UsersTable.tsx
@@ -29,6 +29,8 @@ import {
 import { User } from "@/types/dashboard";
 import { useRouter } from "next/navigation";
 import { TableEmptyState } from "./ui/TableEmptyState";
+import { useDetailRow } from "@/hooks/useDetailRow";
+import { UserDetailSheet } from "./UserDetailSheet";
 
 interface UsersTableProps {
   users: User[];
@@ -42,6 +44,10 @@ export function UsersTable({ users }: UsersTableProps) {
   });
   const [showAssignModal, setShowAssignModal] = useState(false);
   const router = useRouter();
+
+  // Detail panel state lives alongside the modal state above; opening a row
+  // doesn't touch either, so the table keeps whatever the officer had set up.
+  const detail = useDetailRow<User>();
 
   const [teams, setTeams] = useState<{ id: number; name: string }[]>([]);
   const [teamsLoading, setTeamsLoading] = useState(false);
@@ -168,7 +174,7 @@ export function UsersTable({ users }: UsersTableProps) {
               <TableEmptyState colSpan={4} message="No users yet." />
             ) : (
               users.map((user) => (
-                <TableRow key={user.id}>
+                <TableRow key={user.id} {...detail.getRowProps(user)}>
                   <TableCell>{user.name || "N/A"}</TableCell>
                   <TableCell>
                     <a
@@ -195,6 +201,11 @@ export function UsersTable({ users }: UsersTableProps) {
             )}
           </TableBody>
         </Table>
+        <UserDetailSheet
+          user={detail.selected}
+          onOpenChange={detail.onOpenChange}
+          onCloseAutoFocus={detail.onCloseAutoFocus}
+        />
         {showAddModal && (
           <Modal onClose={() => setShowAddModal(false)}>
             <ModalHeader>Add New User</ModalHeader>

--- a/src/components/ui/detail-sheet.tsx
+++ b/src/components/ui/detail-sheet.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+interface DetailSheetProps<T> {
+  /** The row to show, or null when the panel is closed. */
+  record: T | null;
+  onOpenChange: (open: boolean) => void;
+  onCloseAutoFocus: (event: Event) => void;
+  title: (record: T) => React.ReactNode;
+  description?: (record: T) => React.ReactNode;
+  children: (record: T) => React.ReactNode;
+}
+
+/**
+ * Shell for the record detail panels: owns the Sheet wiring and renders its body
+ * from `record` alone, so a panel can never show data the table didn't hand it.
+ * That matters for feedback, where `redactAnonymous` has already stripped the
+ * author server-side -- a panel that fetched its own copy would undo that.
+ */
+export function DetailSheet<T>({
+  record,
+  onOpenChange,
+  onCloseAutoFocus,
+  title,
+  description,
+  children,
+}: DetailSheetProps<T>) {
+  // `record` goes null the instant the panel starts closing, but Radix keeps the
+  // panel mounted for its slide-out animation. Holding the last record keeps the
+  // body from blanking mid-animation. Selecting a different row replaces it
+  // outright, so nothing from the previous row survives into the next open.
+  const [lingering, setLingering] = React.useState(record);
+  if (record !== null && record !== lingering) {
+    setLingering(record);
+  }
+  const shown = record ?? lingering;
+
+  return (
+    <Sheet open={record !== null} onOpenChange={onOpenChange}>
+      <SheetContent onCloseAutoFocus={onCloseAutoFocus}>
+        {shown !== null && (
+          <>
+            <SheetHeader>
+              <SheetTitle>{title(shown)}</SheetTitle>
+              {description && (
+                <SheetDescription>{description(shown)}</SheetDescription>
+              )}
+            </SheetHeader>
+            <SheetBody>{children(shown)}</SheetBody>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/ui/detail.tsx
+++ b/src/components/ui/detail.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// Building blocks for the record detail panels. DetailField is the single place
+// that decides how a missing value renders, so a null `description`, `notes`,
+// `checkedOutAt`, `rating`, or `location` shows a placeholder instead of
+// leaking "null" or "N/A" into the panel.
+
+const EMPTY_PLACEHOLDER = "—";
+
+function DetailSection({
+  title,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"section"> & { title: string }) {
+  return (
+    <section
+      data-slot="detail-section"
+      className={cn("space-y-3", className)}
+      {...props}
+    >
+      <h3 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function DetailGrid({ className, ...props }: React.ComponentProps<"dl">) {
+  return (
+    <dl
+      data-slot="detail-grid"
+      className={cn("grid grid-cols-1 gap-4 sm:grid-cols-2", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Renders one labelled value. Pass the raw value through `value`; only
+ * `null`, `undefined`, and empty/whitespace-only strings are treated as
+ * missing. `0` and `false` are real data (an unrated feedback entry has
+ * `rating: null`, but a capacity of 0 or `isRequired: false` means something)
+ * so they render normally.
+ *
+ * Pass `children` instead when the value needs custom markup, such as badges.
+ */
+function DetailField({
+  label,
+  value,
+  className,
+  children,
+  ...props
+}: Omit<React.ComponentProps<"div">, "children"> & {
+  label: string;
+  value?: React.ReactNode;
+  children?: React.ReactNode;
+}) {
+  const hasChildren = children !== undefined && children !== null;
+  const isMissing =
+    !hasChildren &&
+    (value === null ||
+      value === undefined ||
+      (typeof value === "string" && value.trim() === ""));
+
+  return (
+    <div
+      data-slot="detail-field"
+      className={cn("min-w-0 space-y-1", className)}
+      {...props}
+    >
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd
+        className={cn(
+          "text-sm break-words",
+          isMissing && "text-muted-foreground/60 italic",
+        )}
+      >
+        {hasChildren ? children : isMissing ? EMPTY_PLACEHOLDER : value}
+      </dd>
+    </div>
+  );
+}
+
+/** Shown in place of a relation list when the record has no related rows. */
+function DetailEmpty({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-muted-foreground/60 italic">{children}</p>;
+}
+
+export { DetailSection, DetailGrid, DetailField, DetailEmpty };

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import * as React from "react";
+import { XIcon } from "lucide-react";
+import { Dialog as SheetPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+// A side panel built on the Radix Dialog primitive rather than the hand-rolled
+// Modal in ui/modal.tsx. Radix supplies the parts the detail overlay needs and
+// Modal lacks: Escape to dismiss, a focus trap, focus restoration on close, and
+// background scroll locking.
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "right" | "left";
+}) {
+  return (
+    <SheetPrimitive.Portal>
+      <SheetOverlay />
+      {/* The panel is a flex column so only SheetBody scrolls -- a long
+          attendance roster stays inside the panel instead of overflowing it. */}
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed inset-y-0 z-50 flex h-full w-full flex-col gap-0 border-l bg-popover text-popover-foreground shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:animate-in data-[state=open]:duration-300 sm:max-w-lg",
+          side === "right" &&
+            "right-0 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+          side === "left" &&
+            "left-0 border-r border-l-0 data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close
+          className="absolute top-4 right-4 rounded-sm opacity-70 transition-opacity outline-none hover:opacity-100 focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none"
+          aria-label="Close details"
+        >
+          <XIcon className="size-4" />
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPrimitive.Portal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1 border-b p-6 pr-12", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-body"
+      className={cn("flex-1 space-y-6 overflow-y-auto p-6", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex gap-2 border-t p-6", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-lg font-semibold text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetBody,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/src/hooks/useDetailRow.ts
+++ b/src/hooks/useDetailRow.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+
+// Shared row-trigger behaviour for the officer dashboard tables. Each table
+// keeps its own existing state (add/assign modals, filters); this hook only owns
+// which row's detail panel is open, and it hands back props to spread onto the
+// <TableRow>.
+
+// Elements that own their own clicks. `a[href]` covers both the mailto: link in
+// UsersTable and the three Next.js <Link>s in MeetingsTable, which render as
+// plain anchors. The form controls aren't in a row today; they're listed so an
+// inline control added later doesn't silently open the panel on top of itself.
+const INTERACTIVE_SELECTOR =
+  "button, a[href], input, select, textarea, label, [role='button']";
+
+/**
+ * Decides whether a click that landed inside a row should be ignored, because
+ * the row contains its own control that owns that click.
+ *
+ * `target` is the deepest element the click hit; `row` is the <tr> the handler
+ * is attached to. The `row.contains` check matters because `closest` keeps
+ * climbing past the row -- without it, any ancestor link wrapping the table
+ * would stop every row from opening.
+ */
+function isInteractiveTarget(target: EventTarget | null, row: HTMLElement) {
+  if (!(target instanceof Element)) return false;
+
+  const hit = target.closest(INTERACTIVE_SELECTOR);
+  return hit !== null && row.contains(hit);
+}
+
+export function useDetailRow<T>() {
+  const [selected, setSelected] = React.useState<T | null>(null);
+
+  // The Sheet has no Radix Trigger (the row is the trigger), so remember which
+  // row opened it and aim focus back there when it closes.
+  const originRef = React.useRef<HTMLTableRowElement | null>(null);
+
+  const open = React.useCallback((item: T, row: HTMLTableRowElement) => {
+    originRef.current = row;
+    setSelected(item);
+  }, []);
+
+  const close = React.useCallback(() => setSelected(null), []);
+
+  /** Pass to the Sheet's `onOpenChange` -- covers Escape and backdrop clicks. */
+  const onOpenChange = React.useCallback((next: boolean) => {
+    if (!next) setSelected(null);
+  }, []);
+
+  /** Pass to SheetContent's `onCloseAutoFocus`. */
+  const onCloseAutoFocus = React.useCallback((event: Event) => {
+    const origin = originRef.current;
+    if (!origin || !origin.isConnected) return;
+    event.preventDefault();
+    origin.focus();
+  }, []);
+
+  const getRowProps = React.useCallback(
+    (item: T): React.ComponentProps<"tr"> => ({
+      tabIndex: 0,
+      "aria-haspopup": "dialog",
+      className:
+        "cursor-pointer focus-visible:bg-muted focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
+      onClick: (event) => {
+        if (isInteractiveTarget(event.target, event.currentTarget)) return;
+        open(item, event.currentTarget);
+      },
+      onKeyDown: (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        // A link or button inside the row that has focus handles its own keys.
+        if (event.target !== event.currentTarget) return;
+        // Space would otherwise scroll the page.
+        event.preventDefault();
+        open(item, event.currentTarget);
+      },
+    }),
+    [open],
+  );
+
+  return { selected, open, close, onOpenChange, onCloseAutoFocus, getRowProps };
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,13 @@
+// Date formatters for the detail panels. They return `null` rather than a
+// string for missing values so DetailField applies its own empty-state styling
+// instead of receiving a pre-baked "N/A".
+
+export function formatDateTime(value: Date | string | null | undefined) {
+  if (!value) return null;
+  return new Date(value).toLocaleString();
+}
+
+export function formatDate(value: Date | string | null | undefined) {
+  if (!value) return null;
+  return new Date(value).toLocaleDateString();
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -48,12 +48,19 @@ export interface Meeting {
   team?: {
     name: string;
   };
+  // The dashboard's Prisma query already selects whole Attendance rows, so the
+  // check-in/out timestamps and notes come along for free -- the detail panel's
+  // roster reads them from here rather than issuing its own query.
   attendance: Array<{
+    id: number;
     user: {
       name: string | null;
       email: string;
     };
     status: string;
+    checkedInAt: Date | null;
+    checkedOutAt: Date | null;
+    notes: string | null;
   }>;
 }
 


### PR DESCRIPTION
Clicking a row in the Users, Teams, Meetings, or Feedback tables now opens a side panel with the fields the table omits plus the relevant relations: a user's teams, a meeting's attendance roster, a feedback item's meeting.

Row-level rather than cell-level clicks: a cell target is ambiguous to the user and conflicts with cells that hold their own controls.

- ui/sheet.tsx wraps the Radix Dialog primitive as a right-side panel. Radix supplies Escape dismissal, a focus trap, focus restoration and background scroll locking, none of which the hand-rolled ui/modal.tsx has. Its portal also keeps the panel out of the table's overflow-x-auto container.
- ui/detail.tsx puts the missing-value rule in one place. DetailField checks null/undefined/blank explicitly rather than falsiness, so a null rating or location shows a placeholder while a capacity of 0 stays visible.
- ui/detail-sheet.tsx is a render-prop shell. The four bodies render only from props and never query, so redactAnonymous stays authoritative for feedback.
- useDetailRow owns the selected row and hands back spreadable row props, so TableRow keeps rendering a real <tr>. Its guard ignores clicks landing on a row's own controls, so the mailto: link and the meeting action links don't fire twice.
- Meeting.attendance gains id, checkedInAt, checkedOutAt and notes. The Prisma query already selected whole Attendance rows and only the type narrowed them, so the roster costs no extra query and no extra payload.
- AttendanceStatusBadge extracted from AttendanceTable and shared with the meeting roster so the two can't drift.

Verified against live data: open/close/reopen leaves no stale data, nulls render as a placeholder with no literal "null", a 12-person roster scrolls inside the panel, Enter and Space open a focused row, and focus returns to the originating row on close.